### PR TITLE
feat: improve path resolution for test scripts

### DIFF
--- a/scripts/test_app.py
+++ b/scripts/test_app.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Test FastAPI app directly."""
 import sys
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-
-# Add the backend directory to the path
-sys.path.insert(0, "/Users/ghostradongus/Desktop/Gibsey/gibsey-repo/apps/backend")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_PATH = REPO_ROOT / "apps" / "backend"
+sys.path.insert(0, str(BACKEND_PATH))
 
 # Import the FastAPI app
 try:

--- a/scripts/test_fastapi_direct.py
+++ b/scripts/test_fastapi_direct.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Test FastAPI application directly."""
 import sys
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-
-# Add the backend directory to the path
-sys.path.insert(0, "/Users/ghostradongus/Desktop/Gibsey/gibsey-repo/apps/backend")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_PATH = REPO_ROOT / "apps" / "backend"
+sys.path.insert(0, str(BACKEND_PATH))
 
 # Import the FastAPI app
 try:


### PR DESCRIPTION
## Summary
- fix sys.path handling in test helper scripts to use `Path(__file__).resolve()`
- remove user-specific paths

## Testing
- `ruff check scripts/test_fastapi_direct.py scripts/test_app.py --fix`
- `isort scripts/test_fastapi_direct.py scripts/test_app.py`
- `black scripts/test_fastapi_direct.py scripts/test_app.py`
- `python -m pytest -q` *(fails: No module named pytest)*
- `npm test --prefix apps/frontend -- --watchAll=false` *(fails: Missing script: "test")*
- `python scripts/test_fastapi_direct.py` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python scripts/test_app.py` *(fails: ModuleNotFoundError: No module named 'httpx')*